### PR TITLE
Run EF Core migrations on startup

### DIFF
--- a/src/ShoppingCart.Infrastructure/Program.cs
+++ b/src/ShoppingCart.Infrastructure/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using ShoppingCart.Domain.Interfaces;
 using ShoppingCart.Infrastructure.Repositories;
 
@@ -16,6 +17,13 @@ builder.Services.AddDbContext<ShoppingCartDbContext>(options =>
 builder.Services.AddScoped<ICustomerRepository, CustomerRepository>();
 
 var app = builder.Build();
+
+// apply pending migrations at startup
+using (var scope = app.Services.CreateScope())
+{
+    var dbContext = scope.ServiceProvider.GetRequiredService<ShoppingCartDbContext>();
+    dbContext.Database.Migrate();
+}
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
## Summary
- ensure database migrations are applied on app startup

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fc51181c83328d458280adbd0c00