### PR TITLE
Add images and professional landing page design

### DIFF
--- a/src/shopping-cart-web/public/images/baklava-chocolate.svg
+++ b/src/shopping-cart-web/public/images/baklava-chocolate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="150" viewBox="0 0 200 150">
+  <rect width="200" height="150" fill="#fdf3dc"/>
+  <polygon points="30,120 170,120 100,30" fill="#8b5e3c" stroke="#5c3d27" stroke-width="5"/>
+</svg>

--- a/src/shopping-cart-web/public/images/baklava-classic.svg
+++ b/src/shopping-cart-web/public/images/baklava-classic.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="150" viewBox="0 0 200 150">
+  <rect width="200" height="150" fill="#fdf3dc"/>
+  <polygon points="30,120 170,120 100,30" fill="#e0b56f" stroke="#b88a50" stroke-width="5"/>
+</svg>

--- a/src/shopping-cart-web/public/images/baklava-pistachio.svg
+++ b/src/shopping-cart-web/public/images/baklava-pistachio.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="150" viewBox="0 0 200 150">
+  <rect width="200" height="150" fill="#fdf3dc"/>
+  <polygon points="30,120 170,120 100,30" fill="#c9d65c" stroke="#a0aa4f" stroke-width="5"/>
+</svg>

--- a/src/shopping-cart-web/src/app/landing/landing.html
+++ b/src/shopping-cart-web/src/app/landing/landing.html
@@ -1,4 +1,15 @@
 <div class="landing">
-  <h1>Baklava House</h1>
-  <p>Disfruta las mejores baklavas artesanales. ¡Ordena las tuyas hoy mismo!</p>
+  <section class="hero">
+    <div class="hero-content">
+      <h1>Baklava House</h1>
+      <p>Disfruta las mejores baklavas artesanales. ¡Ordena las tuyas hoy mismo!</p>
+      <button>Ordenar ahora</button>
+    </div>
+  </section>
+
+  <section class="gallery">
+    <img src="images/baklava-classic.svg" alt="Baklava clásico" />
+    <img src="images/baklava-pistachio.svg" alt="Baklava de pistacho" />
+    <img src="images/baklava-chocolate.svg" alt="Baklava de chocolate" />
+  </section>
 </div>

--- a/src/shopping-cart-web/src/app/landing/landing.sass
+++ b/src/shopping-cart-web/src/app/landing/landing.sass
@@ -1,9 +1,46 @@
 .landing
-  text-align: center
-  padding: 2rem
+  display: flex
+  flex-direction: column
+  align-items: center
 
-  h1
-    color: #8B4513
+  .hero
+    width: 100%
+    background: linear-gradient(135deg, #fdf3dc, #e0b56f)
+    color: #5a3e2b
+    text-align: center
+    padding: 4rem 1rem
 
-  p
-    margin-top: 1rem
+    h1
+      font-size: 3rem
+      margin-bottom: 1rem
+      color: #8B4513
+
+    p
+      font-size: 1.25rem
+      margin-bottom: 2rem
+
+    button
+      background-color: #8B4513
+      color: #fff
+      border: none
+      padding: .75rem 2rem
+      font-size: 1rem
+      border-radius: 4px
+      cursor: pointer
+
+      &:hover
+        background-color: #713a0f
+
+  .gallery
+    margin: 3rem 0
+    display: flex
+    gap: 2rem
+    flex-wrap: wrap
+    justify-content: center
+
+    img
+      width: 200px
+      height: 150px
+      object-fit: cover
+      border-radius: 8px
+      box-shadow: 0 4px 6px rgba(0,0,0,.1)

--- a/src/shopping-cart-web/src/styles.sass
+++ b/src/shopping-cart-web/src/styles.sass
@@ -1,1 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
+body
+  margin: 0
+  font-family: Arial, sans-serif
+  background-color: #fffaf2
+  color: #333


### PR DESCRIPTION
## Summary
- Add hero section and image gallery to landing page with call to action
- Style landing with gradient background, responsive gallery, and global typography
- Include SVG assets for different baklava flavors

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d8107874833293a14fc8552680bf